### PR TITLE
NimBLAS should always use the cblas API

### DIFF
--- a/nimblas/private/common.nim
+++ b/nimblas/private/common.nim
@@ -26,7 +26,7 @@ else:
     libPrefix = "lib"
 
 const
-  blas {.strdefine.} = "blas"
+  blas {.strdefine.} = "cblas"
   libName = libPrefix & blas & libSuffix
 
 when defined(atlas):


### PR DESCRIPTION
Currently nimblas try to use cblas_ddot (in nimblas CI) and cblas_dgemm (in Arraymancer CI).

Unfortunately those functions are not available in the default `libblas.so` shipped in Linux distributions.

Instead nimblas should always dlopen `libcblas.so`

cc @narimiran @Araq for popular repos testing.

edit: fix #3 