### PR TITLE
Automatically find the most common BLAS dlls in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Only a subset of BLAS is available under `nimblas`, with more operations added
 on necessity.
 
 For a higher-level linear algebra library based on this, check out
-[neo](http://unicredit.github.io/neo/).
+[arraymancer](https://github.com/mratsim/Arraymancer).
 
 ## Linking BLAS implementations
 
@@ -26,18 +26,19 @@ You can link against a different BLAS implementation by a combination of:
 
 * changing the path for linked libraries (use
   [`--clibdir`](https://nim-lang.org/docs/nimc.html#compiler-usage-command-line-switches)
-  for this)
-* using the `--define:blas` flag. By default, the system tries to load a BLAS
-  library called `blas`, which translates into something called `blas.dll`
-  or `libblas.so` according to the underling operating system. To link,
-  say, the library `libopenblas.so.3` on Linux, you should pass to Nim the
-  option `--define:blas=openblas`.
+  for this).
+* using the `--define:blas` flag. By default (i.e. if you don't set this flag), the system
+  tries to load a BLAS library by looking for the most common blas library file names according
+  to the underling operating system (e.g. `blas.dll`, `openblas.dll`, `libopenblas.dll`,
+  `mkl_intel_lp64.dll` in Windows, `libblas.so`, `libcblas.so` or `libopenblas.so` on Linux, etc).
+  However, if you want to link to one specific library, skipping the automatic search, you can
+  specify it with this flag. For instance, the Linux Arch distribution and its derivatives (such
+  as Manjaro) expose the C API for BLAS inside a library called `libcblas.so` (unlike most other
+  distributions that put it into `libblas.so`). To explicitly link with that library, you can set
+  `--define:blas=cblas`. Note the missing `lib` prefix and `.so` suffix, which nimblas adds automatically
+  (similarly on windows you should not include the `.dll` extension when setting this flag).
 
-For instance, the Linux Arch distribution and its derivatives (such as Manjaro)
-expose the C API for BLAS inside a library called `libcblas.so` (unlike most
-other distributions that put it into `libblas.so`). In this case, you can make
-use of this library with the flag `--define:blas=cblas`. For more examples, see
-the tasks inside [nimblas.nimble](https://github.com/unicredit/nimblas/blob/master/nimblas.nimble).
+For more examples, see the tasks inside [nimblas.nimble](https://github.com/SciNim/nimblas/blob/master/nimblas.nimble).
 
 (Previously there was a more ad hoc mechanism using flags called `-d:atlas`,
 `-d:openblas` or `-d:mkl`, which is deprecated as of NimBLAS 0.2.)
@@ -45,7 +46,9 @@ the tasks inside [nimblas.nimble](https://github.com/unicredit/nimblas/blob/mast
 Packages for various BLAS implementations are available from the package
 managers of many Linux distributions. On OSX one can add the brew formulas
 from [Homebrew Science](https://github.com/Homebrew/homebrew-science), such
-as `brew install homebrew/science/openblas`.
+as `brew install homebrew/science/openblas`. On Windows you can download pre-built
+binaries from the [OpenBLAS github repository](https://github.com/OpenMathLib/OpenBLAS/releases)
+and add the library folder to your PATH or copy it into your executable folder.
 
 You may also need to add suitable paths for the includes and library dirs.
 On OSX, this should do the trick

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Only a subset of BLAS is available under `nimblas`, with more operations added
 on necessity.
 
 For a higher-level linear algebra library based on this, check out
-[arraymancer](https://github.com/mratsim/Arraymancer).
+- [neo](https://andreaferretti.github.io/neo/)
+- [arraymancer](https://github.com/mratsim/Arraymancer).
 
 ## Linking BLAS implementations
 

--- a/nimblas/private/common.nim
+++ b/nimblas/private/common.nim
@@ -15,18 +15,20 @@
 when defined(windows):
   const
     libSuffix = ".dll"
-    libPrefix = ""
+    libPrefix = "(|lib)"
+    blas {.strdefine.} = "(blas|openblas|mkl_intel_lp64)"
 elif defined(macosx):
   const
     libSuffix = ".dylib"
     libPrefix = "lib"
+    blas {.strdefine.} = "blas"
 else:
   const
     libSuffix = ".so(||.3|.2|.1|.0)"
     libPrefix = "lib"
+    blas {.strdefine.} = "blas"
 
 const
-  blas {.strdefine.} = "blas"
   libName = libPrefix & blas & libSuffix
 
 when defined(atlas):

--- a/nimblas/private/common.nim
+++ b/nimblas/private/common.nim
@@ -26,7 +26,7 @@ else:
   const
     libSuffix = ".so(||.3|.2|.1|.0)"
     libPrefix = "lib"
-    blas {.strdefine.} = "(blas|cblas)"
+    blas {.strdefine.} = "(blas|cblas|openblas)"
 
 const
   libName = libPrefix & blas & libSuffix

--- a/nimblas/private/common.nim
+++ b/nimblas/private/common.nim
@@ -26,7 +26,7 @@ else:
   const
     libSuffix = ".so(||.3|.2|.1|.0)"
     libPrefix = "lib"
-    blas {.strdefine.} = "blas"
+    blas {.strdefine.} = "(blas|cblas)"
 
 const
   libName = libPrefix & blas & libSuffix


### PR DESCRIPTION
This uses the fact that dynlib supports patterns to look for the most common BLAS dll names when loading the BLAS library.